### PR TITLE
[feature] Import en content

### DIFF
--- a/config/project/entryTypes/article--c03eff61-59aa-491d-bfa0-db442637813a.yaml
+++ b/config/project/entryTypes/article--c03eff61-59aa-491d-bfa0-db442637813a.yaml
@@ -1,15 +1,34 @@
 color: null
 fieldLayouts:
   1e6091d0-fce7-4a6f-84fd-9a05f8ebb92f:
+    cardView:
+      - 'layoutElement:fb7bf9c8-5781-4575-a811-352514751665'
     tabs:
       -
         elementCondition: null
         elements:
           -
+            dateAdded: '2025-03-30T20:43:10+00:00'
+            elementCondition: null
+            fieldUid: cff97bfa-6eb7-473b-97c0-cc3af58c0f64 # Article ID
+            handle: null
+            includeInCards: false
+            instructions: null
+            label: null
+            providesThumbs: false
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 8d630891-228e-4414-9a60-5ee77df7d111
+            userCondition: null
+            warning: null
+            width: 100
+          -
             autocapitalize: true
             autocomplete: false
             autocorrect: true
             class: null
+            dateAdded: '2025-02-19T09:40:13+00:00'
             disabled: false
             elementCondition: null
             id: null
@@ -24,7 +43,7 @@ fieldLayouts:
             placeholder: null
             providesThumbs: false
             readonly: false
-            requirable: false
+            required: true
             size: null
             step: null
             tip: null
@@ -35,6 +54,7 @@ fieldLayouts:
             warning: null
             width: 100
           -
+            dateAdded: '2025-02-19T09:40:13+00:00'
             elementCondition: null
             fieldUid: 3bde5cb4-3323-4862-906f-40053b1122bc # Main Image
             handle: null
@@ -50,6 +70,7 @@ fieldLayouts:
             warning: null
             width: 100
           -
+            dateAdded: '2025-02-19T09:40:13+00:00'
             elementCondition: null
             fieldUid: 13a0aaca-3bd8-4653-b163-69738ce277c3 # Text
             handle: null
@@ -65,11 +86,13 @@ fieldLayouts:
             warning: null
             width: 100
           -
+            dateAdded: '2025-02-19T09:40:13+00:00'
             elementCondition: null
             type: craft\fieldlayoutelements\HorizontalRule
             uid: aed9da80-acf1-4ba4-8add-5819e0dae19c
             userCondition: null
           -
+            dateAdded: '2025-02-19T09:40:13+00:00'
             elementCondition: null
             fieldUid: 9c0f58c4-4b28-4aca-b80d-3b370bc38f9e # Next Reads
             handle: null
@@ -91,6 +114,7 @@ fieldLayouts:
         elementCondition: null
         elements:
           -
+            dateAdded: '2025-02-19T09:40:13+00:00'
             elementCondition: null
             fieldUid: 0d857c68-7bb1-4ce7-b61f-671446aa8bb3 # SEO
             handle: null
@@ -116,6 +140,6 @@ showSlugField: true
 showStatusField: true
 slugTranslationKeyFormat: null
 slugTranslationMethod: site
-titleFormat: ''
+titleFormat: null
 titleTranslationKeyFormat: null
 titleTranslationMethod: site

--- a/config/project/entryTypes/project--af427185-4826-4e80-bd57-096797b92f4b.yaml
+++ b/config/project/entryTypes/project--af427185-4826-4e80-bd57-096797b92f4b.yaml
@@ -6,6 +6,22 @@ fieldLayouts:
         elementCondition: null
         elements:
           -
+            dateAdded: '2025-03-30T19:35:37+00:00'
+            elementCondition: null
+            fieldUid: 276edf74-a032-4834-b9ef-5783f0b823d4 # Project ID
+            handle: null
+            includeInCards: false
+            instructions: null
+            label: null
+            providesThumbs: false
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: b233697f-406c-4193-a93d-4e222afbe660
+            userCondition: null
+            warning: null
+            width: 100
+          -
             autocapitalize: true
             autocomplete: false
             autocorrect: true

--- a/config/project/fields/articleId--cff97bfa-6eb7-473b-97c0-cc3af58c0f64.yaml
+++ b/config/project/fields/articleId--cff97bfa-6eb7-473b-97c0-cc3af58c0f64.yaml
@@ -1,0 +1,19 @@
+columnSuffix: null
+handle: articleId
+instructions: null
+name: 'Article ID'
+searchable: false
+settings:
+  decimals: 0
+  defaultValue: null
+  max: null
+  min: 0
+  prefix: null
+  previewCurrency: null
+  previewFormat: none
+  size: null
+  step: null
+  suffix: null
+translationKeyFormat: null
+translationMethod: none
+type: craft\fields\Number

--- a/config/project/fields/projectId--276edf74-a032-4834-b9ef-5783f0b823d4.yaml
+++ b/config/project/fields/projectId--276edf74-a032-4834-b9ef-5783f0b823d4.yaml
@@ -1,0 +1,19 @@
+columnSuffix: null
+handle: projectId
+instructions: null
+name: 'Project ID'
+searchable: false
+settings:
+  decimals: 0
+  defaultValue: null
+  max: null
+  min: 0
+  prefix: null
+  previewCurrency: null
+  previewFormat: none
+  size: null
+  step: null
+  suffix: null
+translationKeyFormat: null
+translationMethod: none
+type: craft\fields\Number

--- a/config/project/fields/projectTeamMembers--f81e8821-286e-4e07-86f6-54880a45eafe.yaml
+++ b/config/project/fields/projectTeamMembers--f81e8821-286e-4e07-86f6-54880a45eafe.yaml
@@ -12,5 +12,5 @@ settings:
   placeholder: null
   uiMode: normal
 translationKeyFormat: null
-translationMethod: site
+translationMethod: none
 type: craft\fields\PlainText

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1743365325
+dateModified: 1743367390
 elementSources:
   craft\elements\Entry:
     -
@@ -97,6 +97,7 @@ meta:
     c670b800-a19f-4ca2-a056-283204e59d5d: 'Credit / License' # Credit / License
     c63194ff-c47c-4c20-80b1-39bfedfc3b0f: 'Project Categories' # Project Categories
     c4438391-90e5-49b1-93bd-6fcbbd3aed62: Simple # Simple
+    cff97bfa-6eb7-473b-97c0-cc3af58c0f64: 'Article ID' # Article ID
     d5397ea9-1d37-4f12-bf41-46082d130bd8: Image # Image
     ddc3aedf-983b-4fa7-81eb-69fd761d71af: German # German
     de820dbc-bd7e-4a0f-9554-3d750480d2a4: Projects # Projects

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1741804012
+dateModified: 1743365325
 elementSources:
   craft\elements\Entry:
     -
@@ -78,6 +78,7 @@ meta:
     28f95d3d-986f-41ed-b23b-c2f3b747c2eb: Homepage # Homepage
     34dc108f-02bd-42cb-9481-0693c7bc32b4: 'Tracking Head' # Tracking Head
     91a7ad8a-d35b-4738-b71b-a18f899afc5d: 'Resize: width 2000px' # Resize: width 2000px
+    276edf74-a032-4834-b9ef-5783f0b823d4: 'Project ID' # Project ID
     375cd22a-99b6-4667-8ca6-caf2572459ed: Blog # Blog
     504f909d-20af-4a66-b4a5-46c966689b30: 'Resize: width 1000px' # Resize: width 1000px
     645eb55b-61e5-4ed2-bf31-caed18a16ffb: 'Blog Index' # Blog Index


### PR DESCRIPTION
For importing English blog-posts and projects, we needed to introduce a `articleID` and `projectID` to link the DE and EN content with each other in the exported data. 

Additionally, I disabled translation for the `projectTeammembers` field. 