### PR TITLE
[chore] add woff allowed file extension and fix secondary footer link alignment

### DIFF
--- a/config/general.php
+++ b/config/general.php
@@ -25,7 +25,7 @@ return GeneralConfig::create()
     // Disallow robots
     ->disallowRobots(App::env('DISALLOW_ROBOTS') ?? false)
     // Allow uploading of font data
-    ->extraAllowedFileExtensions(['woff2'])
+    ->extraAllowedFileExtensions(['woff', 'woff2'])
     // Prevent user enumeration attacks
     ->preventUserEnumeration()
     // use emails as user names

--- a/templates/_modules/footer.twig
+++ b/templates/_modules/footer.twig
@@ -88,12 +88,12 @@
   {% endif %}
 
   {% if secondaryFooterLinks|length %}
-    <div class="flex flex-wrap gap-y-1.5 gap-x-3 md:gap-x-6 p-2 md:p-3 text-body-14 border-b border-gray-400">
+    <div class="p-2 md:p-3 text-body-14 border-b border-gray-400">
       {% for linkGroup in secondaryFooterLinks %}
         {% set links = linkGroup.links %}
 
         {% if links|length %}
-          <ul>
+          <ul class="flex flex-wrap gap-y-1.5 gap-x-3 md:gap-x-6">
             {% for link in links %}
               {% switch link.type %}
                 {% case "internalPage" %}


### PR DESCRIPTION
  This PR adds `woff` to `extraAllowedFileExtensions` and fixes the secondary footer link alignment.