### PR TITLE
[fix] remove duplicated project topics and rounds fields

### DIFF
--- a/config/project/entryTypes/project--af427185-4826-4e80-bd57-096797b92f4b.yaml
+++ b/config/project/entryTypes/project--af427185-4826-4e80-bd57-096797b92f4b.yaml
@@ -100,6 +100,22 @@ fieldLayouts:
             warning: null
             width: 100
           -
+            dateAdded: '2025-04-03T14:30:50+00:00'
+            elementCondition: null
+            fieldUid: 860851bc-5058-4f0d-8f3f-481df7e56099 # Project Rounds
+            handle: null
+            includeInCards: false
+            instructions: null
+            label: null
+            providesThumbs: false
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 3ebd30bb-1ff9-483b-8f78-517eb120d5c8
+            userCondition: null
+            warning: null
+            width: 100
+          -
             dateAdded: '2025-03-10T13:44:06+00:00'
             elementCondition: null
             fieldUid: 5a2c3e10-bf78-4986-aecd-f75829889851 # Project Topics
@@ -119,7 +135,7 @@ fieldLayouts:
             dateAdded: '2025-04-03T14:29:07+00:00'
             elementCondition: null
             fieldUid: c85b9b92-e92c-448e-be1b-853494683b99 # Project Technologies
-            handle: projectTechnologies2
+            handle: null
             includeInCards: false
             instructions: null
             label: null
@@ -127,23 +143,7 @@ fieldLayouts:
             required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
-            uid: 9f6ff707-4607-4c5c-8ed0-0bb77eeb6e8f
-            userCondition: null
-            warning: null
-            width: 100
-          -
-            dateAdded: '2025-04-03T14:30:50+00:00'
-            elementCondition: null
-            fieldUid: 860851bc-5058-4f0d-8f3f-481df7e56099 # Project Rounds
-            handle: projectRounds2
-            includeInCards: false
-            instructions: null
-            label: null
-            providesThumbs: false
-            required: false
-            tip: null
-            type: craft\fieldlayoutelements\CustomField
-            uid: 5950d971-54fb-4823-bef5-ed344370a73e
+            uid: d6cf108c-ba1b-47f5-919b-e5f8f8f55077
             userCondition: null
             warning: null
             width: 100
@@ -192,38 +192,6 @@ fieldLayouts:
             tip: null
             type: craft\fieldlayoutelements\CustomField
             uid: 60e77047-8443-4137-aa4f-f2ad68903de0
-            userCondition: null
-            warning: null
-            width: 100
-          -
-            dateAdded: '2025-04-03T14:29:07+00:00'
-            elementCondition: null
-            fieldUid: c85b9b92-e92c-448e-be1b-853494683b99 # Project Technologies
-            handle: null
-            includeInCards: false
-            instructions: null
-            label: null
-            providesThumbs: false
-            required: false
-            tip: null
-            type: craft\fieldlayoutelements\CustomField
-            uid: d6cf108c-ba1b-47f5-919b-e5f8f8f55077
-            userCondition: null
-            warning: null
-            width: 100
-          -
-            dateAdded: '2025-04-03T14:30:50+00:00'
-            elementCondition: null
-            fieldUid: 860851bc-5058-4f0d-8f3f-481df7e56099 # Project Rounds
-            handle: null
-            includeInCards: false
-            instructions: null
-            label: null
-            providesThumbs: false
-            required: false
-            tip: null
-            type: craft\fieldlayoutelements\CustomField
-            uid: 3ebd30bb-1ff9-483b-8f78-517eb120d5c8
             userCondition: null
             warning: null
             width: 100

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1744014045
+dateModified: 1744117259
 elementSources:
   craft\elements\Entry:
     -


### PR DESCRIPTION
Due to probably a merge conflict, the project entry ended up two topics and rounds fields. This PR cleans it up. 

FYI: the data was already imported, but I did it into both fields, so removing one of them won't end up in any loss of data. 

![image](https://github.com/user-attachments/assets/d96d5917-4283-4729-b975-e2d72fabbeea)
