### PR TITLE
[fix] table improvements (center cell text, allow standalone tables)

### DIFF
--- a/config/ckeditor/Standard-(with-Entry-Types).css
+++ b/config/ckeditor/Standard-(with-Entry-Types).css
@@ -14,3 +14,8 @@
   margin-top: 2em;
   margin-bottom: 2em;
 }
+
+.ck.ck-editor figure.table td.text-center,
+.ck.ck-editor figure.table th.text-center {
+  text-align: center;
+}

--- a/config/ckeditor/Standard-(with-Entry-Types).json
+++ b/config/ckeditor/Standard-(with-Entry-Types).json
@@ -19,6 +19,20 @@
         ],
         "element": "span",
         "name": "Highlight"
+      },
+      {
+        "classes": [
+          "text-center"
+        ],
+        "element": "th",
+        "name": "Center Table Header"
+      },
+      {
+        "classes": [
+          "text-center"
+        ],
+        "element": "td",
+        "name": "Center Table Cell"
       }
     ]
   }

--- a/config/project/entryTypes/sideHeadingText--894e5185-035a-41d1-b272-0b6c1608aabf.yaml
+++ b/config/project/entryTypes/sideHeadingText--894e5185-035a-41d1-b272-0b6c1608aabf.yaml
@@ -26,7 +26,7 @@ fieldLayouts:
             orientation: null
             placeholder: null
             readonly: false
-            required: true
+            required: false
             size: null
             step: null
             tip: null

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1784108748
+dateModified: 1784212088
 elementSources:
   craft\elements\Entry:
     -

--- a/templates/_modules/side-heading.twig
+++ b/templates/_modules/side-heading.twig
@@ -1,13 +1,17 @@
+{% set headline = headline|default("") %}
 {% set headlineId = headline|ascii|kebab %}
+
 <div
-  id="{{ headlineId }}"
+  {{ headline|length ? "id=#{headlineId}" }}
   class="mb-10 grid px-2 md:grid-cols-16 md:items-start md:px-5"
 >
-  <h2
-    class="font-surt text-body-22 md:text-body-32 mb-5 break-words md:sticky md:top-[1em] md:col-span-4 md:mb-0 lg:col-span-6"
-  >
-    <a href="#{{ headlineId }}">{{ headline }}</a>
-  </h2>
+  {% if headline|length %}
+    <h2
+      class="font-surt text-body-22 md:text-body-32 mb-5 break-words md:sticky md:top-[1em] md:col-span-4 md:mb-0 lg:col-span-6"
+    >
+      <a href="#{{ headlineId }}">{{ headline }}</a>
+    </h2>
+  {% endif %}
 
   <div
     class="-mx-2 flex flex-col overflow-hidden px-2 md:col-span-11 md:col-start-6 md:mx-0 md:px-0 lg:col-span-9 lg:col-start-8"

--- a/templates/_rich-text/standard.twig
+++ b/templates/_rich-text/standard.twig
@@ -24,9 +24,10 @@
       [ "attr", "body > figure > figcaption", { class: "mt-1 text-gray-600 text-body-12 uppercase md:text-body-13 dark:text-gray" }, false],
 
       [ "attr", "body > figure.table", { class: "figure-table overflow-x-auto w-[calc(100%+32px)] block text-pretty text-body-14 md:text-body-16 my-[60px] first:mt-0 last:mb-0 -mx-2 px-2 md:w-full md:mx-0 md:px-0" }],
+      [ "attr", "body > .figure-table > table tr", { class: "text-left" }, false],
       [ "attr", "body > .figure-table > table", { class: "w-full max-w-full table-fixed min-w-[550px] overflow-hidden table-auto border-collapse border border-gray dark:border-gray-500" }, false],
-      [ "attr", "body > .figure-table > table th", { class: "border-b border-r border-gray dark:border-gray-500 font-normal align-top text-left min-w-35 p-1 bg-gray-100 w-auto dark:bg-gray-800 lg:p-2" }, false],
-      [ "attr", "body > .figure-table > table td", { class: "border-r border-gray dark:border-gray-500 align-top text-left p-1 lg:p-2" }, false],
+      [ "attr", "body > .figure-table > table th", { class: "border-b border-r border-gray dark:border-gray-500 font-normal align-top min-w-35 p-1 bg-gray-100 w-auto dark:bg-gray-800 lg:p-2" }, false],
+      [ "attr", "body > .figure-table > table td", { class: "border-r border-gray dark:border-gray-500 align-top p-1 lg:p-2" }, false],
       [ "attr", "body > .figure-table > table tr", { class: "border-b-gray dark:border-gray-500 border-b" }, false],
 
       [ "attr", "body > blockquote", { class: "border-l-4 border-l-hot-pink pl-2.5 md:pl-4 my-[60px] md:mt-5" }, false],


### PR DESCRIPTION
This PR makes two adjustments to rich-text editor tables, based on feedback:
- Be able to center text within cells (also headers)
- Make headline in side-heading module optional, so that tables can be placed on any page, on their own