### PR TITLE
[fix] standalone, full-width tables

### DIFF
--- a/config/project/entryTypes/sideHeadingText--894e5185-035a-41d1-b272-0b6c1608aabf.yaml
+++ b/config/project/entryTypes/sideHeadingText--894e5185-035a-41d1-b272-0b6c1608aabf.yaml
@@ -52,6 +52,31 @@ fieldLayouts:
             userCondition: null
             warning: null
             width: 100
+          -
+            dateAdded: '2026-07-16T15:58:07+00:00'
+            editCondition: null
+            elementCondition:
+              class: craft\elements\conditions\entries\EntryCondition
+              conditionRules:
+                -
+                  class: craft\elements\conditions\TitleConditionRule
+                  operator: empty
+                  uid: 34785809-5e8b-4935-997a-9aedfcd77c68
+                  value: ''
+              elementType: craft\elements\Entry
+              fieldContext: global
+            elementEditCondition: null
+            fieldUid: 70166b7e-b5b1-4b4d-a336-96fc9c90e1d3 # Full width
+            handle: null
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 6729b6bb-bdf0-414b-a8ab-f68d20cb3239
+            userCondition: null
+            warning: null
+            width: 100
         name: Content
         uid: 263e200c-5f7b-41f9-ba66-d1111fb9fe94
         userCondition: null

--- a/config/project/fields/fullWidth--70166b7e-b5b1-4b4d-a336-96fc9c90e1d3.yaml
+++ b/config/project/fields/fullWidth--70166b7e-b5b1-4b4d-a336-96fc9c90e1d3.yaml
@@ -1,0 +1,13 @@
+columnSuffix: null
+handle: fullWidth
+instructions: null
+name: 'Full width'
+searchable: false
+settings:
+  default: false
+  offLabel: null
+  onLabel: null
+  showLabelsInCards: false
+translationKeyFormat: null
+translationMethod: none
+type: craft\fields\Lightswitch

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1784212088
+dateModified: 1784217487
 elementSources:
   craft\elements\Entry:
     -
@@ -306,6 +306,7 @@ meta:
     15140d29-2c87-492e-84f4-90eb738eb0d8: Columns # Columns
     36123ba7-7de9-48c0-a222-7aab3ad79da9: 'Start Date' # Start Date
     53364b16-adc8-4b34-802f-054c272771c6: 'Projects Index' # Projects Index
+    70166b7e-b5b1-4b4d-a336-96fc9c90e1d3: 'Full width' # Full width
     72564f6d-cb4e-40a8-b30c-99153000f278: Steps # Steps
     586087db-4dd7-43ba-929b-b3f7cef02ff8: w800 # w800
     711863fc-e341-4c43-b45b-dc33dc3c9c2b: Homepage # Homepage

--- a/templates/_modules/side-heading.twig
+++ b/templates/_modules/side-heading.twig
@@ -1,6 +1,7 @@
 {% set headline = headline|default("") %}
 {% set headlineId = headline|ascii|kebab %}
 {% set hasHeading = headline|length %}
+{% set fullWidth = fullWidth|default(false) %}
 
 <div
   {{ hasHeading ? "id=#{headlineId}" }}
@@ -13,9 +14,14 @@
       <a href="#{{ headlineId }}">{{ headline }}</a>
     </h2>
   {% endif %}
-
+  {% set layoutClasses = not hasHeading and fullWidth
+    ? "md:col-span-full md:col-start-1"
+    : "md:col-span-11 md:col-start-6 lg:col-span-9 lg:col-start-8"
+  %}
   <div
-    class="-mx-2 flex flex-col overflow-hidden px-2 md:col-span-11 md:col-start-6 md:mx-0 md:px-0 lg:col-span-9 lg:col-start-8"
+    class="{{
+    layoutClasses
+    }} -mx-2 flex flex-col overflow-hidden px-2 md:mx-0 md:px-0"
   >
     {{ content|raw }}
   </div>

--- a/templates/_modules/side-heading.twig
+++ b/templates/_modules/side-heading.twig
@@ -1,11 +1,12 @@
 {% set headline = headline|default("") %}
 {% set headlineId = headline|ascii|kebab %}
+{% set hasHeading = headline|length %}
 
 <div
-  {{ headline|length ? "id=#{headlineId}" }}
+  {{ hasHeading ? "id=#{headlineId}" }}
   class="mb-10 grid px-2 md:grid-cols-16 md:items-start md:px-5"
 >
-  {% if headline|length %}
+  {% if hasHeading %}
     <h2
       class="font-surt text-body-22 md:text-body-32 mb-5 break-words md:sticky md:top-[1em] md:col-span-4 md:mb-0 lg:col-span-6"
     >

--- a/templates/_partials/entry/sideHeadingText.twig
+++ b/templates/_partials/entry/sideHeadingText.twig
@@ -14,7 +14,9 @@
 {% endset %}
 
 {% set rss %}
-  <h2>{{ entry.title }}</h2>
+  {% if entry.title|length %}
+    <h2>{{ entry.title }}</h2>
+  {% endif %}
   {% include "_rich-text/standard" with {
     text: entry.text
   } only %}

--- a/templates/_partials/entry/sideHeadingText.twig
+++ b/templates/_partials/entry/sideHeadingText.twig
@@ -9,7 +9,8 @@
 
   {% include "_modules/side-heading" with {
     headline: entry.title,
-    content: content
+    content: content,
+    fullWidth: entry.fullWidth
   } only %}
 {% endset %}
 


### PR DESCRIPTION
This PR hopefully concludes the table saga, adding a switch to side-heading modules that allows a full-width layout only when the headline is missing. This way, you can add full-width tables on any page that supports the full module set.