### PR TITLE
[fix] correct issues with rich-text styling

### DIFF
--- a/templates/_modules/side-heading.twig
+++ b/templates/_modules/side-heading.twig
@@ -11,7 +11,7 @@
     <h2
       class="font-surt text-body-22 md:text-body-32 mb-5 break-words md:sticky md:top-[1em] md:col-span-4 md:mb-0 lg:col-span-6"
     >
-      <a href="#{{ headlineId }}">{{ headline }}</a>
+      <a class="anchor" href="#{{ headlineId }}">{{ headline }}</a>
     </h2>
   {% endif %}
   {% set layoutClasses = not hasHeading and fullWidth

--- a/templates/_rich-text/standard.twig
+++ b/templates/_rich-text/standard.twig
@@ -32,7 +32,7 @@
 
       [ "attr", "body > blockquote", { class: "border-l-4 border-l-hot-pink pl-2.5 md:pl-4 my-[60px] md:mt-5" }, false],
       [ "attr", "body > blockquote, body > blockquote > p", { class: "font-surt text-rich-blue text-body-20 md:text-body-24 [hanging-punctuation:first_last] dark:text-sky-blue" }, false],
-      [ "attr", "body > * > a, body * > a", { class: "underline decoration-sky-blue hover:bg-light-blue dark:hover:text-gray-900" }, false],
+      [ "attr", "body > * > a:not(.anchor), body * > a:not(.anchor)", { class: "underline decoration-sky-blue hover:bg-light-blue dark:hover:text-gray-900" }, false],
       [ "attr", "body > p > .button", { class: "uppercase font-surt text-ui-14 md:text-ui-16 border-gray border-l border-r px-[10px] py-[5px] bg-black text-white hover:bg-white hover:text-black transition-colors  rk:bg-white dark:text-gray-900 dark:border-white dark:hover:bg-gray-300" }],
       [ "attr",  ".highlighted", { class: "bg-sky-blue dark:text-gray-900" }]
     ])|raw

--- a/templates/_rich-text/standard.twig
+++ b/templates/_rich-text/standard.twig
@@ -33,7 +33,7 @@
       [ "attr", "body > blockquote", { class: "border-l-4 border-l-hot-pink pl-2.5 md:pl-4 my-[60px] md:mt-5" }, false],
       [ "attr", "body > blockquote, body > blockquote > p", { class: "font-surt text-rich-blue text-body-20 md:text-body-24 [hanging-punctuation:first_last] dark:text-sky-blue" }, false],
       [ "attr", "body > * > a:not(.anchor), body * > a:not(.anchor)", { class: "underline decoration-sky-blue hover:bg-light-blue dark:hover:text-gray-900" }, false],
-      [ "attr", "body > p > .button", { class: "uppercase font-surt text-ui-14 md:text-ui-16 border-gray border-l border-r px-[10px] py-[5px] bg-black text-white hover:bg-white hover:text-black transition-colors  rk:bg-white dark:text-gray-900 dark:border-white dark:hover:bg-gray-300" }],
+      [ "attr", "body > p > .button", { class: "uppercase font-surt text-ui-14 md:text-ui-16 border-black border-l border-r px-[10px] py-[5px] bg-gray-900 text-white hover:bg-transparent hover:text-black transition-colors dark:bg-white dark:hover:bg-transparent dark:text-gray-900 dark:hover:text-white dark:border-white" }],
       [ "attr",  ".highlighted", { class: "bg-sky-blue dark:text-gray-900" }]
     ])|raw
 }}


### PR DESCRIPTION
This PR fixes two issues:
- Embedded side-heading modules within a rich-text field has false link styling applied to headlines since we introduced anchors
- The main button style was broken in dark mode within rich-text fields (luckily not often used so far)